### PR TITLE
Fix: Corrección en la obtención de objetos POJO al migrar de SSR a CSR

### DIFF
--- a/src/lib/paisService.ts
+++ b/src/lib/paisService.ts
@@ -28,9 +28,7 @@ const toPais = ({
 	cioc: string
 }): Pais => {
 	const currency = currencies?.length ? Object.keys(currencies)[0] : ''
-	// TODO: deshacerse de los objetos de dominio,
-	// pide POJOs
-	return { ...new Pais(name?.common, flag, currency, cioc) }
+	return new Pais(name?.common, flag, currency, cioc)
 }
 
 export const paisService = new PaisService()

--- a/src/routes/pais/[code]/+page.svelte
+++ b/src/routes/pais/[code]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	let { data } = $props()
+	export let data
 
 	console.info(data)
 </script>

--- a/src/routes/pais/[code]/+page.svelte
+++ b/src/routes/pais/[code]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	export let data
+	let { data } = $props()
 
 	console.info(data)
 </script>

--- a/src/routes/pais/[code]/+page.ts
+++ b/src/routes/pais/[code]/+page.ts
@@ -1,6 +1,6 @@
 import { paisService } from '$lib/paisService.js'
 
 export async function load({ params }) {
-  const pais = await paisService.datosDePais(params.code)
-  return { pais }
+	const pais = await paisService.datosDePais(params.code)
+	return { pais }
 }


### PR DESCRIPTION
# Descripción

Se identificó y corrigió un problema relacionado con la obtención de objetos POJO teniendo en cuenta que SvelteKit funciona en un entorno híbrido de SSR y CSR. El framework permite múltiples maneras de realizar llamadas externas, dependiendo del contexto:

* `+page.server.ts`: Realiza las llamadas desde el servidor antes de cargar la página, transmitiendo los datos al cliente mediante SSR.
* `+page.ts`: Realiza las llamadas desde el cliente, útil para cambios dinámicos, similar a las prácticas típicas en frameworks como React o Angular.
* `+server.ts`: Proporciona una funcionalidad similar a un servicio, pero en este caso no era necesario ya que contamos con una implementación equivalente mediante servicios.

El problema específico en el ejemplo de países surgió porque la comunicación entre el servidor y el cliente en SSR utiliza la red, lo que impide pasar directamente instancias de clases. Es necesario convertirlos a JSON o DTO, tal como se haría en una comunicación con un backend.

# Cambios Realizados

- **Renombrar `+page.server.ts` a `+page.ts`**: Esto permite que la obtención de datos se realice directamente desde el cliente, eliminando la necesidad de serializar/deserializar los objetos.
- **Refactorización de paisService**: Se asegura que los objetos se devuelvan como instancias de `Pais` directamente.
