### PR TITLE
Minor types refactor

### DIFF
--- a/src/lib/Bandera.svelte
+++ b/src/lib/Bandera.svelte
@@ -1,5 +1,5 @@
 <script lang='ts'>
-  let { bandera } = $props()
+  let { bandera }: { bandera: string } = $props()
 </script>
 <style>
 .bandera {

--- a/src/lib/paisService.ts
+++ b/src/lib/paisService.ts
@@ -3,14 +3,27 @@ import { Pais } from './pais'
 
 import { PUBLIC_API_BASE_URL, PUBLIC_API_VERSION } from '$env/static/public'
 
+type PaisJson = {
+  flags: { svg: string },
+  name: { common: string }
+  translations: { [key: string]: { common: string } }
+  currencies: { [key: string]: { name: string; symbol: string } }
+  cioc: string
+  ccn3: string
+  population: number
+  area: number
+  capital: string
+  timezones: string[]
+}
+
 class PaisService {
   async buscarPais(paisBusqueda: string): Promise<Pais[]> {
-    const response = await axios.get(`${PUBLIC_API_BASE_URL}/${PUBLIC_API_VERSION}/name/${paisBusqueda}`)
+    const response = await axios.get<PaisJson[]>(`${PUBLIC_API_BASE_URL}/${PUBLIC_API_VERSION}/name/${paisBusqueda}`)
     return response.data.map(toPais)
   }
 
   async datosDePais(codigoDePais: string): Promise<Pais> {
-    const response = await axios.get(`${PUBLIC_API_BASE_URL}/${PUBLIC_API_VERSION}/alpha/${codigoDePais}`)
+    const response = await axios.get<PaisJson[]>(`${PUBLIC_API_BASE_URL}/${PUBLIC_API_VERSION}/alpha/${codigoDePais}`)
     return toPais(response.data[0])
   }
 }
@@ -26,18 +39,7 @@ const toPais = ({
   area,
   capital,
   timezones
-}: {
-  flags: { svg: string },
-  name: { common: string }
-  translations: { [key: string]: { common: string } }
-  currencies: { [key: string]: { name: string; symbol: string } }
-  cioc: string
-  ccn3: string
-  population: number
-  area: number
-  capital: string
-  timezones: string[]
-}): Pais => {
+}: PaisJson): Pais => {
   const keysCurrencies = Object.keys(currencies ?? {})
   const countryName = translations['spa']?.common ?? name?.common
   const currency = keysCurrencies?.length ? currencies[keysCurrencies[0]].name : ''

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,12 +1,12 @@
-import { AxiosError } from 'axios'
+import { isAxiosError } from 'axios'
 
 import { PUBLIC_REGION } from '$env/static/public'
 
-export const formatearEntero = (numero: number) =>
+export const formatearEntero = (numero: number): string =>
   new Intl.NumberFormat(PUBLIC_REGION, { minimumFractionDigits: 0 }).format(numero)
 
-export const getErrorMessage = (error: unknown) => {
-  if (error instanceof AxiosError) {
+export const getErrorMessage = (error: unknown): string => {
+  if (isAxiosError(error)) {
     // eslint-disable-next-line no-console
     console.error(error)
     if ((error.status ?? 0) >= 500) {


### PR DESCRIPTION
Agrego un refactor de tipos:

- Se tipa el JSON que responde la API (para que `response.data` no sea `any`)
- Se agregan los return types en las utils para que sea explícito que devuelven
- Se tipa la prop del componente `Bandera`
- Se cambia el checkeo de `instanceof AxiosError` por la función propia de axios `isAxiosError`

Son pavadas realmente, pero creo que suman.