### PR TITLE
Fix stylesheet link path in app.html

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -4,7 +4,7 @@
 <head>
 	<meta charset="utf-8" />
 
-	<link rel="stylesheet" href="./styles.css">
+	<link rel="stylesheet" href="/styles.css">
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 	<link href="https://fonts.googleapis.com/css2?family=Rubik:ital,wght@0,300..900;1,300..900&display=swap"


### PR DESCRIPTION
Al recargar la página estando dentro de la página de país se rompen los estilos generales y la consola tira un error. 

Esto pasa porque en `app.html` se está importando el archivo de styles de manera relativa: `<link rel="stylesheet" href="./styles.css"> `y al hacer refresh estando en `/pais/[code]` no lo encuentra.

Para solucionarlo se puede hacer un import absoluto. Por defecto arranca el import como si estuvieras parado en la carpeta `static`.

https://github.com/user-attachments/assets/a3f89be0-d4e4-4716-b677-c70406664999

<img width="1032" height="294" alt="image" src="https://github.com/user-attachments/assets/ad74526c-f2bf-4e61-a0e1-7753ba3ad6af" />
